### PR TITLE
IMS messages fixes

### DIFF
--- a/Modules/Common/SwLib/IMS/src/ims_messages.h
+++ b/Modules/Common/SwLib/IMS/src/ims_messages.h
@@ -13,13 +13,14 @@ template<typename T>
 struct IMS_PACK ImsMessageBase{
 
     /** Common header */
-    struct {
+    struct IMS_PACK {
         uint64_t timestamp;
         uint8_t tag;
         uint8_t source;
         uint8_t len;
         uint8_t dummy;
     } header;
+    static_assert(sizeof(header) ==  12);
 
     /** Message data */
     union 
@@ -27,8 +28,11 @@ struct IMS_PACK ImsMessageBase{
         uint8_t raw[IMS_MESSAGE_MAXSIZE];
         T msg;
     };
+    static_assert(sizeof(T) <= sizeof(raw));
     
 };
+
+typedef ImsMessageBase<uint8_t[IMS_MESSAGE_MAXSIZE]> ImsMessageRaw;
 
 
 /**


### PR DESCRIPTION
Doing some testing I had some issues where the data was not being properly packed. I made some changes:
> I added pack attribute to IMS message substruct, as the header was taking 16 bytes instead of the expected 12 for some reason during testing with the camera board software.
> I  added static asserts to force compile size check of message header and data, so to avoid larger IMS messages than allowed being defined that might cause data loss or data corruptions 
> As to receive messages before parsing them, I added a raw IMS message definition.